### PR TITLE
fix: add generated client files to docker image

### DIFF
--- a/templates/kapeta/block-type-service/Dockerfile
+++ b/templates/kapeta/block-type-service/Dockerfile
@@ -15,6 +15,7 @@ ADD index.ts /application/index.ts
 ADD src /application/src
 
 RUN npm run build
+ADD src /application/src
 
 HEALTHCHECK --interval=5s --timeout=15s --start-period=5s --retries=10 CMD curl --fail http://localhost:80/__kapeta/health || exit 1
 

--- a/test/resources/examples/todo/Dockerfile
+++ b/test/resources/examples/todo/Dockerfile
@@ -14,6 +14,7 @@ ADD index.ts /application/index.ts
 ADD src /application/src
 
 RUN npm run build
+ADD src /application/src
 
 HEALTHCHECK --interval=5s --timeout=15s --start-period=5s --retries=10 CMD curl --fail http://localhost:80/__kapeta/health || exit 1
 

--- a/test/resources/examples/users/Dockerfile
+++ b/test/resources/examples/users/Dockerfile
@@ -14,6 +14,7 @@ ADD index.ts /application/index.ts
 ADD src /application/src
 
 RUN npm run build
+ADD src /application/src
 
 HEALTHCHECK --interval=5s --timeout=15s --start-period=5s --retries=10 CMD curl --fail http://localhost:80/__kapeta/health || exit 1
 


### PR DESCRIPTION
The npm build command generates clients for the data access layer, we need to include those files in the docker image too, otherwise it fails with:
```


No pending migrations to apply.
Error: Cannot find module './clients/users'
Require stack:
- /home/smo/code/kapeta/sample-nodejs-todo/services/users/src/data/UsersDB.ts
- /home/smo/code/kapeta/sample-nodejs-todo/services/users/src/service/UsersRouteService.tsx
- /home/smo/code/kapeta/sample-nodejs-todo/services/users/index.ts
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (/home/smo/code/kapeta/sample-nodejs-todo/services/users/node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
    at Function.Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/home/smo/code/kapeta/sample-nodejs-todo/services/users/src/data/UsersDB.ts:5:1)
    at Module._compile (node:internal/modules/cjs/loader:1233:14)
    at Module.m._compile (/home/smo/code/kapeta/sample-nodejs-todo/services/users/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1287:10)
    at Object.require.extensions.<computed> [as .ts] (/home/smo/code/kapeta/sample-nodejs-todo/services/users/node_modules/ts-node/src/index.ts:1621:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/smo/code/kapeta/sample-nodejs-todo/services/users/src/data/UsersDB.ts',
    '/home/smo/code/kapeta/sample-nodejs-todo/services/users/src/service/UsersRouteService.tsx',
    '/home/smo/code/kapeta/sample-nodejs-todo/services/users/index.ts'
  ]
}
```