### PR TITLE
fix: bump nodejs dev containers to node 20

### DIFF
--- a/kapeta.yml
+++ b/kapeta.yml
@@ -8,7 +8,7 @@ spec:
     type: url
     value: https://storage.googleapis.com/kapeta-public-cdn/icons/nodejs.svg
   local:
-    image: node:19
+    image: node:20
     workingDir: /workspace
     healthcheck: curl --fail http://localhost:80/__kapeta/health || exit 1
     handlers:


### PR DESCRIPTION
We should bump to a supported node version for development, and node 20 is going LTS in october.
Node 19, however, is already end of life.