### PR TITLE
revert: "fix: bump nodejs dev containers to node 20"

### DIFF
--- a/kapeta.yml
+++ b/kapeta.yml
@@ -8,7 +8,7 @@ spec:
     type: url
     value: https://storage.googleapis.com/kapeta-public-cdn/icons/nodejs.svg
   local:
-    image: node:20
+    image: node:19
     workingDir: /workspace
     healthcheck: curl --fail http://localhost:80/__kapeta/health || exit 1
     handlers:


### PR DESCRIPTION
Reverts kapetacom/codegen-target-nodejs#20