### PR TITLE
Slimming down images

### DIFF
--- a/kapeta.yml
+++ b/kapeta.yml
@@ -8,7 +8,7 @@ spec:
     type: url
     value: https://storage.googleapis.com/kapeta-public-cdn/icons/nodejs.svg
   local:
-    image: node:19
+    image: node:20
     workingDir: /workspace
     healthcheck: curl --fail http://localhost:80/__kapeta/health || exit 1
     handlers:

--- a/templates/kapeta/block-type-service/Dockerfile.hbs
+++ b/templates/kapeta/block-type-service/Dockerfile.hbs
@@ -1,5 +1,5 @@
 ##FILENAME:Dockerfile:merge
-FROM node:19 as build-env
+FROM node:20 as build-env
 
 ADD package.json /application/package.json
 ADD package-lock.json /application/package-lock.json

--- a/templates/kapeta/block-type-service/Dockerfile.hbs
+++ b/templates/kapeta/block-type-service/Dockerfile.hbs
@@ -1,5 +1,5 @@
 ##FILENAME:Dockerfile:merge
-FROM node:19
+FROM node:19 as build-env
 
 ADD package.json /application/package.json
 ADD package-lock.json /application/package-lock.json
@@ -21,6 +21,10 @@ ADD src /application/src
 
 RUN npm run build
 ADD src /application/src
+
+FROM gcr.io/distroless/nodejs20-debian11
+COPY --from=build-env /application /application
+WORKDIR /application
 
 HEALTHCHECK --interval=5s --timeout=15s --start-period=5s --retries=10 CMD curl --fail http://localhost:80/__kapeta/health || exit 1
 

--- a/templates/kapeta/block-type-service/devcontainer.jsonc
+++ b/templates/kapeta/block-type-service/devcontainer.jsonc
@@ -1,7 +1,7 @@
 #FILENAME:.devcontainer/devcontainer.json:merge
 {
     "name": "{{dashify data.metadata.name}}",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:19",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
     "containerEnv": {
         "KAPETA_LOCAL_SERVER": "0.0.0.0",
         "KAPETA_LOCAL_CLUSTER_HOST": "host.docker.internal",

--- a/test/resources/examples/todo/.devcontainer/devcontainer.json
+++ b/test/resources/examples/todo/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "kapeta-todo",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:19",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
     "containerEnv": {
         "KAPETA_LOCAL_SERVER": "0.0.0.0",
         "KAPETA_LOCAL_CLUSTER_HOST": "host.docker.internal",

--- a/test/resources/examples/todo/Dockerfile
+++ b/test/resources/examples/todo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19
+FROM node:19 as build-env
 
 ADD package.json /application/package.json
 ADD package-lock.json /application/package-lock.json
@@ -15,6 +15,10 @@ ADD src /application/src
 
 RUN npm run build
 ADD src /application/src
+
+FROM gcr.io/distroless/nodejs20-debian11
+COPY --from=build-env /application /application
+WORKDIR /application
 
 HEALTHCHECK --interval=5s --timeout=15s --start-period=5s --retries=10 CMD curl --fail http://localhost:80/__kapeta/health || exit 1
 

--- a/test/resources/examples/todo/Dockerfile
+++ b/test/resources/examples/todo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19 as build-env
+FROM node:20 as build-env
 
 ADD package.json /application/package.json
 ADD package-lock.json /application/package-lock.json

--- a/test/resources/examples/users/.devcontainer/devcontainer.json
+++ b/test/resources/examples/users/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "kapeta-users",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:19",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
     "containerEnv": {
         "KAPETA_LOCAL_SERVER": "0.0.0.0",
         "KAPETA_LOCAL_CLUSTER_HOST": "host.docker.internal",

--- a/test/resources/examples/users/Dockerfile
+++ b/test/resources/examples/users/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19
+FROM node:19 as build-env
 
 ADD package.json /application/package.json
 ADD package-lock.json /application/package-lock.json
@@ -15,6 +15,10 @@ ADD src /application/src
 
 RUN npm run build
 ADD src /application/src
+
+FROM gcr.io/distroless/nodejs20-debian11
+COPY --from=build-env /application /application
+WORKDIR /application
 
 HEALTHCHECK --interval=5s --timeout=15s --start-period=5s --retries=10 CMD curl --fail http://localhost:80/__kapeta/health || exit 1
 

--- a/test/resources/examples/users/Dockerfile
+++ b/test/resources/examples/users/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19 as build-env
+FROM node:20 as build-env
 
 ADD package.json /application/package.json
 ADD package-lock.json /application/package-lock.json


### PR DESCRIPTION
Using the distroless docker image.
Updated to latest LTS
The image size went from 1.24GB to 274mb 😱 
Should make pushing images a lot faster too