### PR TITLE
fix: Update CLI language target to handle prod env values

### DIFF
--- a/src/target/template-helpers.ts
+++ b/src/target/template-helpers.ts
@@ -254,10 +254,13 @@ export const addTemplateHelpers = (engine: HandleBarsType, data: any, context: a
         // Get the content inside the {{#prettier}}...{{/prettier}} block
         const content = options.fn(this);
 
-        // Extract Prettier options from the helper's hash arguments
         const prettierOptions = {
-            // Default options can be specified here
             parser: 'typescript',
+            printWidth: 120,
+            proseWrap: 'never',
+            singleQuote: true,
+            tabWidth: 4,
+            // Overwrite with Prettier options from the helper's hash arguments
             ...options.hash,
         };
 

--- a/src/target/template-helpers.ts
+++ b/src/target/template-helpers.ts
@@ -251,23 +251,24 @@ export const addTemplateHelpers = (engine: HandleBarsType, data: any, context: a
     });
 
     engine.registerHelper('prettier', function (this: any, options) {
+        // Get the content inside the {{#prettier}}...{{/prettier}} block
         const content = options.fn(this);
 
-        try {
-            // Format the content using Prettier
-            const formattedContent = prettier.format(content, {
-                parser: 'typescript',
-                printWidth: 120,
-                proseWrap: 'never',
-                singleQuote: true,
-                tabWidth: 4,
-            });
+        // Extract Prettier options from the helper's hash arguments
+        const prettierOptions = {
+            // Default options can be specified here
+            parser: 'typescript',
+            ...options.hash,
+        };
 
-            return new Handlebars.SafeString(formattedContent);
+        try {
+            const formattedContent = prettier.format(content, prettierOptions);
+
+            return new engine.SafeString(formattedContent);
         } catch (error) {
             console.error('Error formatting content with Prettier:', error);
             // Return unformatted content on error
-            return new Handlebars.SafeString(content);
+            return new engine.SafeString(content);
         }
     });
 };

--- a/templates/kapeta/block-type-cli/.env
+++ b/templates/kapeta/block-type-cli/.env
@@ -1,0 +1,4 @@
+//#FILENAME:.env:create-only
+{{#consumers-of-type 'kapeta/resource-type-rest-client'}}
+KAPETA_CONSUMER_SERVICE_{{uppercase metadata.name}}_REST="http://replace-me-with-url.com/",
+{{~/consumers-of-type}}

--- a/templates/kapeta/block-type-cli/.env.development
+++ b/templates/kapeta/block-type-cli/.env.development
@@ -1,0 +1,4 @@
+//#FILENAME:.env.development:create-only
+{{#consumers-of-type 'kapeta/resource-type-rest-client'}}
+KAPETA_CONSUMER_SERVICE_{{uppercase metadata.name}}_REST="http://replace-me-with-url.com/",
+{{~/consumers-of-type}}

--- a/templates/kapeta/block-type-cli/.env.development
+++ b/templates/kapeta/block-type-cli/.env.development
@@ -1,4 +1,7 @@
 //#FILENAME:.env.development:create-only
+#
+# Run `npm run prepare:hosts` to update these values
+#
 {{#consumers-of-type 'kapeta/resource-type-rest-client'}}
 KAPETA_CONSUMER_SERVICE_{{uppercase metadata.name}}_REST="http://replace-me-with-url.com/",
 {{~/consumers-of-type}}

--- a/templates/kapeta/block-type-cli/README.md
+++ b/templates/kapeta/block-type-cli/README.md
@@ -26,7 +26,7 @@ bin/{{assetName data.metadata.name}} [arguments]
 
 To run the CLI in dev mode, run the following commands:
 ```bash
-npm run dev [arguments]
+npm run start:dev [arguments]
 ```
 
 To rerun the CLI in dev mode while watching for changes, run the following commands:

--- a/templates/kapeta/block-type-cli/bin-command.hbs
+++ b/templates/kapeta/block-type-cli/bin-command.hbs
@@ -3,4 +3,4 @@
 
 process.title = '{{assetName data.metadata.name}}';
 
-require('../dist/src/index.js');
+require('../dist/cjs/index.js');

--- a/templates/kapeta/block-type-cli/index.ts.hbs
+++ b/templates/kapeta/block-type-cli/index.ts.hbs
@@ -12,7 +12,7 @@ program
     });
 
 // Catch all command to show a custom message for unknown commands
-program.command('*', { noHelp: true }).action(() => {});
+program.command('*', { hidden: true }).action(() => {});
 // Event listener for unknown commands
 program.on('command:*', function (operands) {
     console.error(`Error: Unknown command '${operands[0]}'.`);

--- a/templates/kapeta/block-type-cli/kapeta.md
+++ b/templates/kapeta/block-type-cli/kapeta.md
@@ -46,4 +46,18 @@ const { {{#kaplang-rest-methods spec.source namespace=metadata.name}} {{lowerFir
 {{/prettier}}
 ```
 {{/consumers-of-type}}
+
+## Environment Variables
+
+The `.env` or `.env.development` files has to contain the following environment variables:
+
+{{#consumers-of-type 'kapeta/resource-type-rest-client'}}
+- `KAPETA_CONSUMER_SERVICE_{{uppercase metadata.name}}_REST`
+{{~/consumers-of-type}}
+
+
+The values will be updated automatically in `.env.development` when you run the CLI in dev mode (`npm run start:dev` or `npm run watch`). 
+
+To run the CLI in production mode, you need to set the environment variables manually in the `.env` file.
+
 {{/consumes}}

--- a/templates/kapeta/block-type-cli/package.json.hbs
+++ b/templates/kapeta/block-type-cli/package.json.hbs
@@ -3,24 +3,23 @@
     "name": "@{{lowercase data.metadata.name}}",
     "version": "0.0.1",
     "description": "",
-    "main": "dist/src/index.js",
-    "type": "commonjs",
+    "main": "dist/cjs/index.js",
     "scripts": {
-        "prepare:hosts": "node -r ts-node/register ./scripts/prepare-hosts.ts",
-        "prebuild": "cpx \"./package.json\" dist/src",
+        "prepare:hosts": "ts-node ./scripts/prepare-hosts.ts",
+        "prebuild": "rm -rf dist",
         "build": "tsc",
         "postbuild": "pkg package.json",
-        "predev": "npm run prepare:hosts",
-        "dev": "ts-node -r tsconfig-paths/register src/index.ts",
+        "prestart:dev": "npm run prepare:hosts",
+        "start:dev": "dotenvx run --env-file=.env.development -- ts-node src/index.ts",
         "prewatch": "npm run prepare:hosts",
-        "watch": "nodemon --exec 'ts-node -r tsconfig-paths/register' src/index.ts"
+        "watch": "dotenvx run --env-file=.env.development -- nodemon --exec 'ts-node' src/index.ts"
     },
     "bin": {
         "{{assetName data.metadata.name}}": "./bin/{{assetName data.metadata.name}}"
     },
     "pkg": {
         "scripts": [
-            "dist/src/{{assetName data.metadata.name}}.js"
+            "dist/cjs/index.js"
         ],
         "assets": [],
         "targets": [
@@ -40,22 +39,33 @@
     "dependencies": {
         "@kapeta/nodejs-api-client": "^0.2.0",
         "@kapeta/npm-package-handler": "^0.0.21",
-        "commander": "^12.0.0"
-        {{#consumes 'kapeta/resource-type-rest-client'}},
+        {{#consumes 'kapeta/resource-type-rest-client'}}
             "@kapeta/sdk-config": "^2",
             "@kapeta/sdk-rest": "^1.0.1",
-            "@kapeta/sdk-rest-client": "^3.3"
+            "@kapeta/sdk-rest-client": "^3.3",
         {{/consumes}}
+        "commander": "^12.0.0",
+        "dotenv": "^16.4.4",
+        "tslib": "^2.6.2"
     },
     "bundledDependencies": true,
     "devDependencies": {
+        "@dotenvx/dotenvx": "^0.16.0",
         "@kapeta/prettier-config": "^0.6.2",
+        "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
         "@types/node": "^20.11.17",
-        "cpx": "^1.5.0",
         "nodemon": "^3.0.3",
         "pkg": "^5.8.1",
         "prettier": "^3.2.5",
+        "rollup": "^4.12.0",
+        "rollup-plugin-bundle-size": "^1.0.3",
+        "rollup-plugin-tsconfig-paths": "^1.5.2",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.3.3"
     },
     "prettier": "@kapeta/prettier-config"

--- a/templates/kapeta/block-type-cli/prepare-hosts.ts.hbs
+++ b/templates/kapeta/block-type-cli/prepare-hosts.ts.hbs
@@ -21,7 +21,7 @@ const RESOURCES = [
 (async function () {
     const config = await Config.init(BASE_PATH);
 
-    let envContents = '';
+    let envContents = "#\n# Run `npm run prepare:hosts` to update these values\n#\n";
     for (const resource of RESOURCES) {
         const host = await config.getServiceAddress(resource.name, resource.type);
         if (host === null) {

--- a/templates/kapeta/block-type-cli/prepare-hosts.ts.hbs
+++ b/templates/kapeta/block-type-cli/prepare-hosts.ts.hbs
@@ -3,12 +3,11 @@
 // GENERATED SOURCE - DO NOT EDIT
 //
 import * as Path from 'path';
-import { writeFile, mkdir } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import Config from '@kapeta/sdk-config';
 
 const BASE_PATH = Path.resolve(__dirname, '..');
-const CONFIG_DIR = Path.resolve(BASE_PATH, 'config');
-const HOSTS_FILE = Path.join(CONFIG_DIR, 'hosts.development.json');
+const ENV_FILE = Path.join(BASE_PATH, '.env.development');
 
 const RESOURCES = [
     {{#consumers-of-type 'kapeta/resource-type-rest-client'}}
@@ -22,27 +21,25 @@ const RESOURCES = [
 (async function () {
     const config = await Config.init(BASE_PATH);
 
-    // Ensure the config directory exists
-    await mkdir(CONFIG_DIR, { recursive: true });
-
-    const hosts: { [key: string]: string } = {};
+    let envContents = '';
     for (const resource of RESOURCES) {
         const host = await config.getServiceAddress(resource.name, resource.type);
         if (host === null) {
             console.error('Failed to get host for resource: %s', resource.name);
             process.exit(1);
         }
-        hosts[resource.name] = host;
+        // Convert each resource into an environment variable declaration
+        envContents += `KAPETA_CONSUMER_SERVICE_${resource.name.toUpperCase()}_${resource.type.toUpperCase()}="${host}"\n`;
     }
 
-    await writeFile(HOSTS_FILE, JSON.stringify(hosts, null, 2), {
+    await writeFile(ENV_FILE, envContents.trim(), {
         flag: 'w',
     });
 })()
     .then(() => {
-        console.log('Hosts file written: %s', HOSTS_FILE);
+        console.log('Env file written: %s', ENV_FILE);
     })
     .catch((e) => {
-        console.error('Failed to write hosts file: %s', HOSTS_FILE, e);
+        console.error('Failed to write env file: %s', ENV_FILE, e);
         process.exit(1);
     });

--- a/templates/kapeta/block-type-cli/rest-clients-index.ts.hbs
+++ b/templates/kapeta/block-type-cli/rest-clients-index.ts.hbs
@@ -1,18 +1,27 @@
 {{#consumes 'kapeta/resource-type-rest-client'}}
     //#FILENAME:src/.generated/clients/index.ts:write-always
-    import hostsConfig from '../../../config/hosts.development.json';
     {{#consumers-of-type 'kapeta/resource-type-rest-client'}}
     {{#kaplang-rest-methods spec.source namespace=metadata.name~}}
         import { {{controller-name this}}Client } from './{{controller-name this}}Client';
     {{~/kaplang-rest-methods}}
-    {{/consumers-of-type}}    
-
-
+    {{/consumers-of-type}}
+    import 'dotenv/config';
+    
+    
     export const initRestClients = () => {
+        {{#consumers-of-type 'kapeta/resource-type-rest-client'}}
+        {{#kaplang-rest-methods spec.source namespace=metadata.name~}}
+            if(!process.env.KAPETA_CONSUMER_SERVICE_{{uppercase ../metadata.name}}_REST) {
+                throw new Error('Environment varianble "KAPETA_CONSUMER_SERVICE_{{uppercase ../metadata.name}}_REST" is not defined');
+            }            
+        {{~/kaplang-rest-methods}}
+        {{/consumers-of-type}}    
+
+
         return {
             {{#consumers-of-type 'kapeta/resource-type-rest-client'}}
             {{#kaplang-rest-methods spec.source namespace=metadata.name~}}
-                {{lowerFirst (controller-name this)}}Client: new {{controller-name this}}Client(false).$withBaseUrl(hostsConfig.{{string ../metadata.name}}),
+                {{lowerFirst (controller-name this)}}Client: new {{controller-name this}}Client(false).$withBaseUrl(process.env.KAPETA_CONSUMER_SERVICE_{{uppercase ../metadata.name}}_REST),
             {{~/kaplang-rest-methods}}
             {{/consumers-of-type}}    
         };

--- a/templates/kapeta/block-type-cli/rollup.config.mjs
+++ b/templates/kapeta/block-type-cli/rollup.config.mjs
@@ -1,0 +1,42 @@
+import packageJson from './package.json' assert { type: 'json' };
+import commonjs from '@rollup/plugin-commonjs';
+import tsConfigPaths from 'rollup-plugin-tsconfig-paths';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+import terser from '@rollup/plugin-terser';
+import bundleSize from 'rollup-plugin-bundle-size';
+
+export default {
+    input: 'src/index.ts',
+    output: [
+        {
+            file: packageJson.main,
+            format: 'cjs',
+            name: packageJson.name,
+            generatedCode: 'es2015',
+            compact: true,
+            sourcemap: true,
+        },
+    ],
+    plugins: [
+        commonjs({
+            include: /node_modules/, // Ensure that only node_modules are processed
+        }),
+        tsConfigPaths({
+            tsConfigPath: './tsconfig.build.json',
+        }),
+        json({
+            namedExports: false,
+        }),
+        nodeResolve({
+            moduleDirectories: ['.', 'node_modules'],
+            preferBuiltins: true,
+        }),
+        typescript({
+            tsconfig: './tsconfig.build.json',
+        }),
+        terser(),
+        bundleSize(),
+    ],
+};

--- a/templates/kapeta/block-type-cli/rollup.config.mjs
+++ b/templates/kapeta/block-type-cli/rollup.config.mjs
@@ -1,3 +1,4 @@
+//#FILENAME:rollup.config.mjs:create-only
 import packageJson from './package.json' assert { type: 'json' };
 import commonjs from '@rollup/plugin-commonjs';
 import tsConfigPaths from 'rollup-plugin-tsconfig-paths';

--- a/templates/kapeta/block-type-cli/tsconfig.build.json
+++ b/templates/kapeta/block-type-cli/tsconfig.build.json
@@ -1,0 +1,9 @@
+//#FILENAME:tsconfig.build.json:create-only
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "noEmit": true
+  }
+}

--- a/templates/kapeta/block-type-cli/tsconfig.json
+++ b/templates/kapeta/block-type-cli/tsconfig.json
@@ -16,7 +16,7 @@
         "sourceMap": true,
         "lib": ["es2022"],
         "paths": {
-            "generated:*": ["src/.generated/*"]
+            "generated:*": ["./src/.generated/*"]
         }
     },
     "ts-node": {

--- a/templates/kapeta/block-type-cli/tsconfig.json
+++ b/templates/kapeta/block-type-cli/tsconfig.json
@@ -15,7 +15,6 @@
         "outDir": "dist",
         "sourceMap": true,
         "lib": ["es2022"],
-        "baseUrl": ".",
         "paths": {
             "generated:*": ["src/.generated/*"]
         }
@@ -23,5 +22,6 @@
     "ts-node": {
         "require": ["tsconfig-paths/register"]
     },
-    "include": ["src/**/*.ts"],
+    "include": ["src"],
+    "exclude": ["node_modules", "dist"]
 }

--- a/test/resources/examples/cli/.env
+++ b/test/resources/examples/cli/.env
@@ -1,0 +1,2 @@
+KAPETA_CONSUMER_SERVICE_GAMES_REST="http://replace-me-with-url.com/",
+KAPETA_CONSUMER_SERVICE_USERS_REST="http://replace-me-with-url.com/",

--- a/test/resources/examples/cli/.env.development
+++ b/test/resources/examples/cli/.env.development
@@ -1,2 +1,5 @@
+#
+# Run `npm run prepare:hosts` to update these values
+#
 KAPETA_CONSUMER_SERVICE_GAMES_REST="http://replace-me-with-url.com/",
 KAPETA_CONSUMER_SERVICE_USERS_REST="http://replace-me-with-url.com/",

--- a/test/resources/examples/cli/.env.development
+++ b/test/resources/examples/cli/.env.development
@@ -1,0 +1,2 @@
+KAPETA_CONSUMER_SERVICE_GAMES_REST="http://replace-me-with-url.com/",
+KAPETA_CONSUMER_SERVICE_USERS_REST="http://replace-me-with-url.com/",

--- a/test/resources/examples/cli/.kapeta/merged/package.json
+++ b/test/resources/examples/cli/.kapeta/merged/package.json
@@ -2,24 +2,23 @@
     "name": "@kapeta/cli",
     "version": "0.0.1",
     "description": "",
-    "main": "dist/src/index.js",
-    "type": "commonjs",
+    "main": "dist/cjs/index.js",
     "scripts": {
-        "prepare:hosts": "node -r ts-node/register ./scripts/prepare-hosts.ts",
-        "prebuild": "cpx \"./package.json\" dist/src",
+        "prepare:hosts": "ts-node ./scripts/prepare-hosts.ts",
+        "prebuild": "rm -rf dist",
         "build": "tsc",
         "postbuild": "pkg package.json",
-        "predev": "npm run prepare:hosts",
-        "dev": "ts-node -r tsconfig-paths/register src/index.ts",
+        "prestart:dev": "npm run prepare:hosts",
+        "start:dev": "dotenvx run --env-file=.env.development -- ts-node src/index.ts",
         "prewatch": "npm run prepare:hosts",
-        "watch": "nodemon --exec 'ts-node -r tsconfig-paths/register' src/index.ts"
+        "watch": "dotenvx run --env-file=.env.development -- nodemon --exec 'ts-node' src/index.ts"
     },
     "bin": {
         "cli": "./bin/cli"
     },
     "pkg": {
         "scripts": [
-            "dist/src/cli.js"
+            "dist/cjs/index.js"
         ],
         "assets": [],
         "targets": [
@@ -39,20 +38,31 @@
     "dependencies": {
         "@kapeta/nodejs-api-client": "^0.2.0",
         "@kapeta/npm-package-handler": "^0.0.21",
-        "commander": "^12.0.0",
         "@kapeta/sdk-config": "^2",
         "@kapeta/sdk-rest": "^1.0.1",
-        "@kapeta/sdk-rest-client": "^3.3"
+        "@kapeta/sdk-rest-client": "^3.3",
+        "commander": "^12.0.0",
+        "dotenv": "^16.4.4",
+        "tslib": "^2.6.2"
     },
     "bundledDependencies": true,
     "devDependencies": {
+        "@dotenvx/dotenvx": "^0.16.0",
         "@kapeta/prettier-config": "^0.6.2",
+        "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
         "@types/node": "^20.11.17",
-        "cpx": "^1.5.0",
         "nodemon": "^3.0.3",
         "pkg": "^5.8.1",
         "prettier": "^3.2.5",
+        "rollup": "^4.12.0",
+        "rollup-plugin-bundle-size": "^1.0.3",
+        "rollup-plugin-tsconfig-paths": "^1.5.2",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.3.3"
     },
     "prettier": "@kapeta/prettier-config"

--- a/test/resources/examples/cli/README.md
+++ b/test/resources/examples/cli/README.md
@@ -25,7 +25,7 @@ bin/cli [arguments]
 
 To run the CLI in dev mode, run the following commands:
 ```bash
-npm run dev [arguments]
+npm run start:dev [arguments]
 ```
 
 To rerun the CLI in dev mode while watching for changes, run the following commands:

--- a/test/resources/examples/cli/bin/cli
+++ b/test/resources/examples/cli/bin/cli
@@ -2,4 +2,4 @@
 
 process.title = 'cli';
 
-require('../dist/src/index.js');
+require('../dist/cjs/index.js');

--- a/test/resources/examples/cli/kapeta.md
+++ b/test/resources/examples/cli/kapeta.md
@@ -47,3 +47,15 @@ import { initRestClients } from 'generated:clients';
 
 const { usersClient, usersHighRankedClient } = initRestClients();
 ```
+
+## Environment Variables
+
+The `.env` or `.env.development` files has to contain the following environment variables:
+
+- `KAPETA_CONSUMER_SERVICE_GAMES_REST`
+- `KAPETA_CONSUMER_SERVICE_USERS_REST`
+
+The values will be updated automatically in `.env.development` when you run the CLI in dev mode (`npm run start:dev` or `npm run watch`). 
+
+To run the CLI in production mode, you need to set the environment variables manually in the `.env` file.
+

--- a/test/resources/examples/cli/kapeta.md
+++ b/test/resources/examples/cli/kapeta.md
@@ -34,7 +34,7 @@ See below for details on how to use the REST clients.
 To use the "games" REST Client(s) - simply add the following code to your service:
 
 ```typescript
-import { initRestClients } from 'generated:clients';
+import { initRestClients } from "generated:clients";
 
 const { gamesClient } = initRestClients();
 ```
@@ -43,7 +43,7 @@ const { gamesClient } = initRestClients();
 To use the "users" REST Client(s) - simply add the following code to your service:
 
 ```typescript
-import { initRestClients } from 'generated:clients';
+import { initRestClients } from "generated:clients";
 
 const { usersClient, usersHighRankedClient } = initRestClients();
 ```

--- a/test/resources/examples/cli/kapeta.md
+++ b/test/resources/examples/cli/kapeta.md
@@ -34,7 +34,7 @@ See below for details on how to use the REST clients.
 To use the "games" REST Client(s) - simply add the following code to your service:
 
 ```typescript
-import { initRestClients } from "generated:clients";
+import { initRestClients } from 'generated:clients';
 
 const { gamesClient } = initRestClients();
 ```
@@ -43,7 +43,7 @@ const { gamesClient } = initRestClients();
 To use the "users" REST Client(s) - simply add the following code to your service:
 
 ```typescript
-import { initRestClients } from "generated:clients";
+import { initRestClients } from 'generated:clients';
 
 const { usersClient, usersHighRankedClient } = initRestClients();
 ```

--- a/test/resources/examples/cli/package.json
+++ b/test/resources/examples/cli/package.json
@@ -2,24 +2,23 @@
     "name": "@kapeta/cli",
     "version": "0.0.1",
     "description": "",
-    "main": "dist/src/index.js",
-    "type": "commonjs",
+    "main": "dist/cjs/index.js",
     "scripts": {
-        "prepare:hosts": "node -r ts-node/register ./scripts/prepare-hosts.ts",
-        "prebuild": "cpx \"./package.json\" dist/src",
+        "prepare:hosts": "ts-node ./scripts/prepare-hosts.ts",
+        "prebuild": "rm -rf dist",
         "build": "tsc",
         "postbuild": "pkg package.json",
-        "predev": "npm run prepare:hosts",
-        "dev": "ts-node -r tsconfig-paths/register src/index.ts",
+        "prestart:dev": "npm run prepare:hosts",
+        "start:dev": "dotenvx run --env-file=.env.development -- ts-node src/index.ts",
         "prewatch": "npm run prepare:hosts",
-        "watch": "nodemon --exec 'ts-node -r tsconfig-paths/register' src/index.ts"
+        "watch": "dotenvx run --env-file=.env.development -- nodemon --exec 'ts-node' src/index.ts"
     },
     "bin": {
         "cli": "./bin/cli"
     },
     "pkg": {
         "scripts": [
-            "dist/src/cli.js"
+            "dist/cjs/index.js"
         ],
         "assets": [],
         "targets": [
@@ -39,20 +38,31 @@
     "dependencies": {
         "@kapeta/nodejs-api-client": "^0.2.0",
         "@kapeta/npm-package-handler": "^0.0.21",
-        "commander": "^12.0.0",
         "@kapeta/sdk-config": "^2",
         "@kapeta/sdk-rest": "^1.0.1",
-        "@kapeta/sdk-rest-client": "^3.3"
+        "@kapeta/sdk-rest-client": "^3.3",
+        "commander": "^12.0.0",
+        "dotenv": "^16.4.4",
+        "tslib": "^2.6.2"
     },
     "bundledDependencies": true,
     "devDependencies": {
+        "@dotenvx/dotenvx": "^0.16.0",
         "@kapeta/prettier-config": "^0.6.2",
+        "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
         "@types/node": "^20.11.17",
-        "cpx": "^1.5.0",
         "nodemon": "^3.0.3",
         "pkg": "^5.8.1",
         "prettier": "^3.2.5",
+        "rollup": "^4.12.0",
+        "rollup-plugin-bundle-size": "^1.0.3",
+        "rollup-plugin-tsconfig-paths": "^1.5.2",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.3.3"
     },
     "prettier": "@kapeta/prettier-config"

--- a/test/resources/examples/cli/rollup.config.mjs
+++ b/test/resources/examples/cli/rollup.config.mjs
@@ -1,0 +1,42 @@
+import packageJson from './package.json' assert { type: 'json' };
+import commonjs from '@rollup/plugin-commonjs';
+import tsConfigPaths from 'rollup-plugin-tsconfig-paths';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+import terser from '@rollup/plugin-terser';
+import bundleSize from 'rollup-plugin-bundle-size';
+
+export default {
+    input: 'src/index.ts',
+    output: [
+        {
+            file: packageJson.main,
+            format: 'cjs',
+            name: packageJson.name,
+            generatedCode: 'es2015',
+            compact: true,
+            sourcemap: true,
+        },
+    ],
+    plugins: [
+        commonjs({
+            include: /node_modules/, // Ensure that only node_modules are processed
+        }),
+        tsConfigPaths({
+            tsConfigPath: './tsconfig.build.json',
+        }),
+        json({
+            namedExports: false,
+        }),
+        nodeResolve({
+            moduleDirectories: ['.', 'node_modules'],
+            preferBuiltins: true,
+        }),
+        typescript({
+            tsconfig: './tsconfig.build.json',
+        }),
+        terser(),
+        bundleSize(),
+    ],
+};

--- a/test/resources/examples/cli/scripts/prepare-hosts.ts
+++ b/test/resources/examples/cli/scripts/prepare-hosts.ts
@@ -2,12 +2,11 @@
 // GENERATED SOURCE - DO NOT EDIT
 //
 import * as Path from 'path';
-import { writeFile, mkdir } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import Config from '@kapeta/sdk-config';
 
 const BASE_PATH = Path.resolve(__dirname, '..');
-const CONFIG_DIR = Path.resolve(BASE_PATH, 'config');
-const HOSTS_FILE = Path.join(CONFIG_DIR, 'hosts.development.json');
+const ENV_FILE = Path.join(BASE_PATH, '.env.development');
 
 const RESOURCES = [
     {
@@ -23,27 +22,25 @@ const RESOURCES = [
 (async function () {
     const config = await Config.init(BASE_PATH);
 
-    // Ensure the config directory exists
-    await mkdir(CONFIG_DIR, { recursive: true });
-
-    const hosts: { [key: string]: string } = {};
+    let envContents = '';
     for (const resource of RESOURCES) {
         const host = await config.getServiceAddress(resource.name, resource.type);
         if (host === null) {
             console.error('Failed to get host for resource: %s', resource.name);
             process.exit(1);
         }
-        hosts[resource.name] = host;
+        // Convert each resource into an environment variable declaration
+        envContents += `KAPETA_CONSUMER_SERVICE_${resource.name.toUpperCase()}_${resource.type.toUpperCase()}="${host}"\n`;
     }
 
-    await writeFile(HOSTS_FILE, JSON.stringify(hosts, null, 2), {
+    await writeFile(ENV_FILE, envContents.trim(), {
         flag: 'w',
     });
 })()
     .then(() => {
-        console.log('Hosts file written: %s', HOSTS_FILE);
+        console.log('Env file written: %s', ENV_FILE);
     })
     .catch((e) => {
-        console.error('Failed to write hosts file: %s', HOSTS_FILE, e);
+        console.error('Failed to write env file: %s', ENV_FILE, e);
         process.exit(1);
     });

--- a/test/resources/examples/cli/scripts/prepare-hosts.ts
+++ b/test/resources/examples/cli/scripts/prepare-hosts.ts
@@ -22,7 +22,7 @@ const RESOURCES = [
 (async function () {
     const config = await Config.init(BASE_PATH);
 
-    let envContents = '';
+    let envContents = '#\n# Run `npm run prepare:hosts` to update these values\n#\n';
     for (const resource of RESOURCES) {
         const host = await config.getServiceAddress(resource.name, resource.type);
         if (host === null) {

--- a/test/resources/examples/cli/src/.generated/clients/index.ts
+++ b/test/resources/examples/cli/src/.generated/clients/index.ts
@@ -1,12 +1,24 @@
-import hostsConfig from '../../../config/hosts.development.json';
 import { GamesClient } from './GamesClient';
 import { UsersClient } from './UsersClient';
 import { UsersHighRankedClient } from './UsersHighRankedClient';
+import 'dotenv/config';
 
 export const initRestClients = () => {
+    if (!process.env.KAPETA_CONSUMER_SERVICE_GAMES_REST) {
+        throw new Error('Environment varianble "KAPETA_CONSUMER_SERVICE_GAMES_REST" is not defined');
+    }
+    if (!process.env.KAPETA_CONSUMER_SERVICE_USERS_REST) {
+        throw new Error('Environment varianble "KAPETA_CONSUMER_SERVICE_USERS_REST" is not defined');
+    }
+    if (!process.env.KAPETA_CONSUMER_SERVICE_USERS_REST) {
+        throw new Error('Environment varianble "KAPETA_CONSUMER_SERVICE_USERS_REST" is not defined');
+    }
+
     return {
-        gamesClient: new GamesClient(false).$withBaseUrl(hostsConfig.games),
-        usersClient: new UsersClient(false).$withBaseUrl(hostsConfig.users),
-        usersHighRankedClient: new UsersHighRankedClient(false).$withBaseUrl(hostsConfig.users),
+        gamesClient: new GamesClient(false).$withBaseUrl(process.env.KAPETA_CONSUMER_SERVICE_GAMES_REST),
+        usersClient: new UsersClient(false).$withBaseUrl(process.env.KAPETA_CONSUMER_SERVICE_USERS_REST),
+        usersHighRankedClient: new UsersHighRankedClient(false).$withBaseUrl(
+            process.env.KAPETA_CONSUMER_SERVICE_USERS_REST
+        ),
     };
 };

--- a/test/resources/examples/cli/src/index.ts
+++ b/test/resources/examples/cli/src/index.ts
@@ -11,7 +11,7 @@ program
     });
 
 // Catch all command to show a custom message for unknown commands
-program.command('*', { noHelp: true }).action(() => {});
+program.command('*', { hidden: true }).action(() => {});
 // Event listener for unknown commands
 program.on('command:*', function (operands) {
     console.error(`Error: Unknown command '${operands[0]}'.`);

--- a/test/resources/examples/cli/tsconfig.build.json
+++ b/test/resources/examples/cli/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "moduleResolution": "Bundler",
+        "module": "ESNext",
+        "noEmit": true
+    }
+}

--- a/test/resources/examples/cli/tsconfig.json
+++ b/test/resources/examples/cli/tsconfig.json
@@ -15,7 +15,7 @@
         "sourceMap": true,
         "lib": ["es2022"],
         "paths": {
-            "generated:*": ["src/.generated/*"]
+            "generated:*": ["./src/.generated/*"]
         }
     },
     "ts-node": {

--- a/test/resources/examples/cli/tsconfig.json
+++ b/test/resources/examples/cli/tsconfig.json
@@ -14,7 +14,6 @@
         "outDir": "dist",
         "sourceMap": true,
         "lib": ["es2022"],
-        "baseUrl": ".",
         "paths": {
             "generated:*": ["src/.generated/*"]
         }
@@ -22,5 +21,6 @@
     "ts-node": {
         "require": ["tsconfig-paths/register"]
     },
-    "include": ["src/**/*.ts"]
+    "include": ["src"],
+    "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Changes in this PR
- Use rollup to build 
- Use .env files to set URL's for api endpoints
  - This was easier than referencing a `config/hosts.production.json` file outside the dist folder
- Update script names to align with other projects (`start:dev` for example) 
- When initialising rest clients trow exception if env var is missing
